### PR TITLE
Update Authorization -> access_token (API changes).

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -26,7 +26,7 @@ const AuthService = {
     try {
       const apiResponse = await ApiService.post(resource, data);
 
-      const accessToken: string = apiResponse.data.Authorization;
+      const accessToken: string = apiResponse.data.access_token;
       const user: User = apiResponse.data.user;
 
       return {
@@ -51,7 +51,7 @@ const AuthService = {
         password
       });
 
-      const accessToken: string = apiResponse.data.Authorization;
+      const accessToken: string = apiResponse.data.access_token;
       const user: User = apiResponse.data.user;
 
       return {


### PR DESCRIPTION
* This caused to raise an `uncaught exception: undefined` where the API service would try to assign an `undefined` token to `auth/accessToken`.
* This was because of the API changes that returned `Authorization: (Jwt token)` to `access_token: (Jwt token)`.