### PR TITLE
Temporarily disabled HTML to avoid XSS.

### DIFF
--- a/src/components/Home/Post/Common/Content.vue
+++ b/src/components/Home/Post/Common/Content.vue
@@ -3,6 +3,7 @@
     <vue-markdown
       v-if="markdown"
       :source="content"
+      :html="false"
       :class="[
         $vuetify.theme.dark ? 'white--text' : 'grey--text text--darken-4'
       ]"


### PR DESCRIPTION
Set HTML to false for Vue-Markdown component.