### PR TITLE
Markdown content height limit and style adjustments.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -47,5 +47,8 @@ export default class App extends Vue {}
       margin-bottom: -0.5em;
     }
   }
+
+  scrollbar-color: #848484 #424242;
+  scrollbar-width: thin;
 }
 </style>

--- a/src/components/Home/Post/Common/Composer.vue
+++ b/src/components/Home/Post/Common/Composer.vue
@@ -28,7 +28,7 @@
 
             <v-btn
               icon
-              class="teal mb3 ml1 hidden-md-and-up"
+              class="teal mb3 ml1"
               elevation="2"
               dark
               small

--- a/src/components/Home/Post/Common/Content.vue
+++ b/src/components/Home/Post/Common/Content.vue
@@ -1,11 +1,14 @@
 <template>
-  <div>
+  <div ref="postContent">
     <vue-markdown
+      ref="markdownContent"
       v-if="markdown"
       :source="content"
       :prerender="sanitize"
       :class="[
-        $vuetify.theme.dark ? 'white--text' : 'grey--text text--darken-4'
+        $vuetify.theme.dark ? 'white--text' : 'grey--text text--darken-4',
+        'content',
+        { more: showMore }
       ]"
     />
 
@@ -18,6 +21,18 @@
       :length="500"
       v-else
     />
+
+    <v-btn
+      block
+      outlined
+      small
+      v-show="showMoreIndicator && markdown"
+      color="primary"
+      @click="toggleMoreContent"
+      class="mt2"
+    >
+      Show More
+    </v-btn>
   </div>
 </template>
 
@@ -47,6 +62,26 @@ export default class Content extends Vue {
 
   @Getter("markdown", { namespace: "settings" }) private markdown!: boolean;
 
+  private showMore: boolean = false;
+  private showMoreIndicator: boolean = false;
+
+  $refs!: {
+    postContent: HTMLDivElement;
+  };
+
+  private mounted() {
+    setTimeout(() => {
+      if (this.$refs.postContent.offsetHeight >= 140) {
+        this.showMoreIndicator = true;
+      }
+    }, 250);
+  }
+
+  private toggleMoreContent() {
+    this.showMore = true;
+    this.showMoreIndicator = false;
+  }
+
   private sanitize(content: string) {
     const sanitizedContent: string = DOMPurify.sanitize(content);
     return sanitizedContent;
@@ -56,4 +91,13 @@ export default class Content extends Vue {
 
 <style lang="scss" scoped>
 @import url(https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css);
+
+.content {
+  &.more {
+    max-height: 100%;
+  }
+
+  max-height: 10em;
+  overflow: hidden;
+}
 </style>

--- a/src/components/Settings/Content.vue
+++ b/src/components/Settings/Content.vue
@@ -14,10 +14,6 @@
       >
         Note that using Markdown will import and load the required plugins which
         may slow down performance.
-
-        <br />
-
-        There is no height limit at the moment so posts might get long.
       </v-alert>
 
       <v-list>


### PR DESCRIPTION
* Adjusted scroll bar colors and size.
* Removed content setting comment for Markdown.
* Set Markdown as the default content preview.
* Always show send button for commenting/replying composer to prevent any confusion.